### PR TITLE
fix(x6): 修复IE11.900版本下text标签不显示文本内容问题

### DIFF
--- a/packages/x6/src/shape/standard/text-block.ts
+++ b/packages/x6/src/shape/standard/text-block.ts
@@ -68,9 +68,8 @@ export const TextBlock = Base.define({
   attrHooks: {
     text: {
       set(text: string, { cell, view, refBBox, elem, attrs }) {
-        if (elem instanceof HTMLElement) {
-          elem.textContent = text
-        } else {
+        elem.textContent = text
+        if (!(elem instanceof HTMLElement)) {
           // No foreign object
           const style = (attrs.style as Attr.SimpleAttrs) || {}
           const wrapValue = { text, width: -5, height: '100%' }


### PR DESCRIPTION
fix(x6): 修复IE11.900版本下text标签不显示文本内容问题

Description
IE 11.900版本下 text 标签不能显示文本

Motivation and Context
该版本不支持通过text的text属性设置内容，需要直接设置textContent属性才能生效